### PR TITLE
Add wget dependency to install step on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ You need these two packages to parse json and html: `jq`, `xmllint`
 ### 1.1) Install on Mac
 Install [brew](https://brew.sh/) first if you haven't done so already.
 
-Now install `jq`:
+Now install `jq` and `wget`:
 ````
-brew install jq
+brew install jq wget
 ````
 
 `xmllint` is installed by default on MacOS Ventura (and perhaps older).


### PR DESCRIPTION
On Sonoma `wget` is not provided by system.